### PR TITLE
List support.  This gets lists working but its kind of ugly.  Would like to simplify how dmProvider subclasses handle get/set.

### DIFF
--- a/dataProvider/data/Device.WiFi.EndPoint.json
+++ b/dataProvider/data/Device.WiFi.EndPoint.json
@@ -4,6 +4,10 @@
   "is_list" : true,
   "properties":
     [
+      {"name": "SSID", "type": "string", "optional": false, "writable": false, "version": "2.0"},
+      {"name": "SecurityType", "type": "string", "optional": false, "writable": false, "version": "2.0"},
+      {"name": "Channel", "type": "string", "optional": false, "writable": false, "version": "2.0"},
+      {"name": "Mode", "type": "string", "optional": false, "writable": false, "version": "2.0"},
       {"name": "Status", "type": "string", "optional": false, "writable": false, "version": "2.0"}
     ]
 }

--- a/dataProvider/dmPropertyInfo.cpp
+++ b/dataProvider/dmPropertyInfo.cpp
@@ -19,6 +19,7 @@ dmPropertyInfo::dmPropertyInfo()
   , m_type(dmValueType_Unknown)
   , m_optional(false)
   , m_writable(false)
+  , m_index(0)
 {
 }
 
@@ -42,8 +43,12 @@ void dmPropertyInfo::setIsWritable(bool b)
   m_writable = b;
 }
 
-void
-dmPropertyInfo::setFullName(std::string const& name)
+void dmPropertyInfo::setFullName(std::string const& name)
 {
   m_full_name = name;
+}
+
+void dmPropertyInfo::setIndex(uint32_t i)
+{
+  m_index = i;
 }

--- a/dataProvider/dmPropertyInfo.h
+++ b/dataProvider/dmPropertyInfo.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "dmValueType.h"
+#include "rtLog.h"
 
 class dmProviderDatabase;
 
@@ -40,6 +41,9 @@ public:
   inline std::string const& fullName() const
     { return m_full_name; }
 
+  inline uint32_t index() const
+    { return m_index; }
+
 public:
   dmPropertyInfo();
   void setName(std::string const& name);
@@ -47,6 +51,7 @@ public:
   void setIsOptional(bool b);
   void setIsWritable(bool b);
   void setFullName(std::string const& name);
+  void setIndex(uint32_t i);
 
 private:
   std::string m_name;
@@ -54,6 +59,7 @@ private:
   bool        m_optional;
   bool        m_writable;
   std::string m_full_name;
+  uint32_t    m_index;
 };
 
 

--- a/dataProvider/dmProvider.cpp
+++ b/dataProvider/dmProvider.cpp
@@ -38,8 +38,7 @@ dmProvider::doGet(std::vector<dmPropertyInfo> const& params, std::vector<dmQuery
     auto itr = m_provider_functions.find(propInfo.name());
     if ((itr != m_provider_functions.end()) && (itr->second.getter != nullptr))
     {
-      dmValue val = itr->second.getter();
-      temp.addValue(propInfo, val);
+      itr->second.getter(propInfo, temp);
     }
     else
     {
@@ -77,8 +76,7 @@ dmProvider::doSet(std::vector<dmNamedValue> const& params, std::vector<dmQueryRe
     auto itr = m_provider_functions.find(value.name());
     if ((itr != m_provider_functions.end()) && (itr->second.setter != nullptr))
     {
-      itr->second.setter(value.value());
-      temp.addValue(value.info(), value.value());
+      itr->second.setter(value.info(), value.value(), temp);
     }
     else
     {
@@ -140,4 +138,9 @@ dmProvider::onSet(std::string const& propertyName, setter_function func)
     funcs.getter = nullptr;
     m_provider_functions.insert(std::make_pair(propertyName, funcs));
   }
+}
+
+size_t dmProvider::getListSize()
+{
+  return 0;
 }

--- a/dataProvider/dmProvider.h
+++ b/dataProvider/dmProvider.h
@@ -34,15 +34,16 @@ public:
   virtual void doSet(std::vector<dmNamedValue> const& params, std::vector<dmQueryResult>& result);
 
 protected:
-  virtual void doGet(dmPropertyInfo const& param, dmQueryResult& result);
+  virtual void doGet(dmPropertyInfo const& info, dmQueryResult& result);
   virtual void doSet(dmPropertyInfo const& info, dmValue const& value, dmQueryResult& result);
 
-  using getter_function = std::function<dmValue (void)>;
-  using setter_function = std::function<void (dmValue const& value)>;
+  using getter_function = std::function<void (dmPropertyInfo const& info, dmQueryResult& result)>;
+  using setter_function = std::function<void (dmPropertyInfo const& info, dmValue const& value, dmQueryResult& result)>;
 
   void onGet(std::string const& propertyName, getter_function func);
   void onSet(std::string const& propertyName, setter_function func);
 
+  virtual size_t getListSize();
 protected:
   std::string m_name;
 

--- a/dataProvider/dmProviderDatabase.cpp
+++ b/dataProvider/dmProviderDatabase.cpp
@@ -401,10 +401,14 @@ dmProviderDatabase::createQuery(dmProviderOperation op, char const* queryString)
     return nullptr;
 
   std::string objectName(queryString);
+
   if (dmUtility::isWildcard(objectName.c_str()))
     objectName = dmUtility::trimWildcard(objectName);
   else
     objectName = dmUtility::trimProperty(objectName);
+
+  if (dmUtility::isListIndex(objectName.c_str()))
+    objectName = dmUtility::trimProperty(objectName);//trim again to remove index
 
   std::shared_ptr<dmProviderInfo> providerInfo = getProviderByObjectName(objectName);
 
@@ -437,6 +441,8 @@ dmProviderDatabase::makeProviderInfo(char const* s)
     providerInfo->setObjectName(p->valuestring);
   if ((p = cJSON_GetObjectItem(json, "provider")) != nullptr)
     providerInfo->setProviderName(p->valuestring);
+  if ((p = cJSON_GetObjectItem(json, "is_list")) != nullptr)
+    providerInfo->setIsList(p->type == cJSON_True);
 
   // rtLog_Debug("adding object:%s", providerInfo->objectName().c_str());
   if ((p = cJSON_GetObjectItem(json, "properties")) != nullptr)

--- a/dataProvider/dmProviderInfo.cpp
+++ b/dataProvider/dmProviderInfo.cpp
@@ -19,6 +19,7 @@ dmProviderInfo::dmProviderInfo()
   : m_objectName()
   , m_providerName()
   , m_props()
+  , m_isList(false)
 {
 }
 
@@ -37,6 +38,10 @@ void dmProviderInfo::addProperty(dmPropertyInfo const& propInfo)
   m_props.push_back(propInfo);
 }
 
+void dmProviderInfo::setIsList(bool isList)
+{
+  m_isList = isList;
+}
 
 dmPropertyInfo
 dmProviderInfo::getPropertyInfo(char const* propertyName) const

--- a/dataProvider/dmProviderInfo.h
+++ b/dataProvider/dmProviderInfo.h
@@ -37,6 +37,9 @@ public:
   inline std::vector<dmPropertyInfo> const& properties() const
     { return m_props; }
 
+  inline bool isList() const
+    { return m_isList; }
+
   dmPropertyInfo getPropertyInfo(char const* s) const;
 
 private:
@@ -44,10 +47,12 @@ private:
   void setProviderName(std::string const& name);
   void setObjectName(std::string const& name);
   void addProperty(dmPropertyInfo const& propInfo);
+  void setIsList(bool isList);
 
 private:
   std::string m_objectName;
   std::string m_providerName;
   std::vector<dmPropertyInfo> m_props;
+  bool m_isList;
 };
 #endif

--- a/dataProvider/sample_provider_wifi.cpp
+++ b/dataProvider/sample_provider_wifi.cpp
@@ -15,52 +15,58 @@
 #include "dmProviderHost.h"
 #include "dmProvider.h"
 #include <rtLog.h>
+#include <rtError.h>
 #include <unistd.h>
 
-class MyProvider : public dmProvider
+class WiFiProvider : public dmProvider
 {
 public:
-  MyProvider() : m_noiseLevel("10dB"), m_userName("xcam_user")
+  WiFiProvider() : m_noiseLevel("10dB"), m_userName("xcam_user")
   {
-    rtLog_Debug("MyProvider::CTOR");
+    rtLog_Debug("WiFiProvider::CTOR");
 
     // use lambda for simple stuff
-    onGet("X_RDKCENTRAL-COM_IPv4Address", []() -> dmValue {
-      return "127.0.0.1";
+    onGet("X_RDKCENTRAL-COM_IPv4Address", [](dmPropertyInfo const& info, dmQueryResult& result) -> void {
+      result.addValue(info, "127.0.0.1");
     });
 
     // can use member function
-    onGet("X_RDKCENTRAL-COM_NoiseLevel", std::bind(&MyProvider::getNoiseLevel, this));
-    onSet("X_RDKCENTRAL-COM_NoiseLevel", std::bind(&MyProvider::setNoiseLevel, this, std::placeholders::_1));
+    onGet("X_RDKCENTRAL-COM_NoiseLevel", std::bind(&WiFiProvider::getNoiseLevel, this, std::placeholders::_1, std::placeholders::_2));
+    onSet("X_RDKCENTRAL-COM_NoiseLevel", std::bind(&WiFiProvider::setNoiseLevel, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
+    onGet("EndPointNumberOfEntries", [](dmPropertyInfo const& info, dmQueryResult& result) -> void { 
+      result.addValue(info, 3);
+    });
   }
 
 private:
-  dmValue getNoiseLevel()
+  void getNoiseLevel(dmPropertyInfo const& info, dmQueryResult& result)
   {
-    rtLog_Debug("MyProvider::getNoiseLevel %s\n", m_noiseLevel.c_str());
-    return m_noiseLevel.c_str();
+    rtLog_Debug("WiFiProvider::getNoiseLevel %s\n", m_noiseLevel.c_str());
+    result.addValue(info, m_noiseLevel.c_str());
   }
 
-  void setNoiseLevel(dmValue const& value)
+  void setNoiseLevel(dmPropertyInfo const& info, dmValue const& value, dmQueryResult& result)
   {
-    rtLog_Debug("MyProvider::setNoiseLevel %s\n", value.toString().c_str());
+    rtLog_Debug("WiFiProvider::setNoiseLevel %s\n", value.toString().c_str());
     m_noiseLevel = value.toString();
+    result.addValue(info, value);
   }
 
 protected:
   // override the basic get and use ladder if/else
-  virtual void doGet(dmPropertyInfo const& param, dmQueryResult& result)
+  virtual void doGet(dmPropertyInfo const& info, dmQueryResult& result)
   {
-    rtLog_Debug("MyProvider::doGet %s\n", param.name().c_str());
-    if (param.name() == "X_RDKCENTRAL-COM_UserName")
+    rtLog_Debug("WiFiProvider::doGet %s\n", info.name().c_str());
+    if (info.name() == "X_RDKCENTRAL-COM_UserName")
     {
-      result.addValue(param, m_userName);
+      result.addValue(info, m_userName);
     }
   }
 
   virtual void doSet(dmPropertyInfo const& info, dmValue const& value, dmQueryResult& result)
   {
-    rtLog_Debug("MyProvider::doSet %s: %s\n", info.name().c_str(), value.toString().c_str());
+    rtLog_Debug("WiFiProvider::doSet %s: %s\n", info.name().c_str(), value.toString().c_str());
     if (info.name() == "X_RDKCENTRAL-COM_UserName")
     {
       m_userName = value.toString();
@@ -72,13 +78,92 @@ private:
   std::string m_userName;
 };
 
-class EndpointProvider : public dmProvider
+class EndPointProvider : public dmProvider
 {
 public:
-  EndpointProvider()
+  EndPointProvider()
   {
-    onGet("EndpointNumberofItems", []() -> dmValue { return 3; });
+    m_endPoints.push_back({"NETGEAR1","WPA","0","12","Online"});
+    m_endPoints.push_back({"RAWHIDE123","WPA+PKI","1","3","Online"});
+    m_endPoints.push_back({"XB3","Comcast","0","11","Offline"});
+    onGet("Status", std::bind(&EndPointProvider::getStatus, this, std::placeholders::_1, std::placeholders::_2));
+    onSet("Status", std::bind(&EndPointProvider::setStatus, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    onGet("SSID", std::bind(&EndPointProvider::getSSID, this, std::placeholders::_1, std::placeholders::_2));
+    onSet("SSID", std::bind(&EndPointProvider::setSSID, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
   }
+protected:
+  virtual size_t getListSize()
+  {
+    return m_endPoints.size();
+  }
+private:
+  void getStatus(dmPropertyInfo const& info, dmQueryResult& result)
+  {
+    rtLog_Debug("WiFiProvider::getStatus index=%u\n", info.index());
+    if(info.index() < m_endPoints.size())
+    {
+      result.addValue(info, m_endPoints[info.index()].status);
+    }
+    else
+    {
+      result.setStatus(RT_ERROR_INVALID_ARG);
+      result.setStatusMsg("Index out of range");
+    }
+  }
+
+  void setStatus(dmPropertyInfo const& info, dmValue const& value, dmQueryResult& result)
+  {
+    rtLog_Debug("WiFiProvider::setStatus index=%u value=%s\n", info.index(), value.toString().c_str());
+    if(info.index() < m_endPoints.size())
+    {
+      m_endPoints[info.index()].status = value.toString();
+      result.addValue(info, value);
+    }
+    else
+    {
+      result.setStatus(RT_ERROR_INVALID_ARG);
+      result.setStatusMsg("Index out of range");
+    }
+  }
+
+  void getSSID(dmPropertyInfo const& info, dmQueryResult& result)
+  {
+    rtLog_Debug("WiFiProvider::getSSID index=%u\n", info.index());
+    if(info.index() < m_endPoints.size())
+    {
+      result.addValue(info, m_endPoints[info.index()].ssid);
+    }
+    else
+    {
+      result.setStatus(RT_ERROR_INVALID_ARG);
+      result.setStatusMsg("Index out of range");
+    }
+  }
+
+  void setSSID(dmPropertyInfo const& info, dmValue const& value, dmQueryResult& result)
+  {
+    rtLog_Debug("WiFiProvider::setSSID index=%u value=%s\n", info.index(), value.toString().c_str());
+    if(info.index() < m_endPoints.size())
+    {
+      m_endPoints[info.index()].ssid = value.toString();
+      result.addValue(info, value);
+    }
+    else
+    {
+      result.setStatus(RT_ERROR_INVALID_ARG);
+      result.setStatusMsg("Index out of range");
+    }
+  }
+
+  struct EndPoint
+  {
+    std::string ssid;
+    std::string securityType;
+    std::string channel;
+    std::string mode;
+    std::string status;
+  };
+  std::vector<EndPoint> m_endPoints;
 };
 
 int main()
@@ -86,8 +171,8 @@ int main()
   dmProviderHost* host = dmProviderHost::create();
   host->start();
 
-  host->registerProvider("Device.WiFi", std::unique_ptr<dmProvider>(new MyProvider()));
-  host->registerProvider("Device.WiFi.EndPoint", std::unique_ptr<dmProvider>(new EndpointProvider()));
+  host->registerProvider("Device.WiFi", std::unique_ptr<dmProvider>(new WiFiProvider()));
+  host->registerProvider("Device.WiFi.EndPoint", std::unique_ptr<dmProvider>(new EndPointProvider()));
 
   while (true)
   {


### PR DESCRIPTION
	add index property to dmPropertyInfo
	add isList property to dmProviderInfo
	add parseListProperty to dmUltilies to parse out the index
	update dmProviderHost to check if dmProviderInfo is a list, then parse out index
	update dmProvider (and sample) to take dmPropertyInfo and drmQueryresult params across the board